### PR TITLE
fix(xml): add nan checks for int types

### DIFF
--- a/sheepdog/xml/evaluators/__init__.py
+++ b/sheepdog/xml/evaluators/__init__.py
@@ -94,10 +94,9 @@ class Evaluator(object):
         if value is None:
             return None
 
-        # handle NaN
-        if self.data_type == "float" and math.isnan(float(value)):
+        # handle NaN, possibly occurs in types (float, int)
+        if self.data_type in ["float", "int"] and math.isnan(float(value)):
             return None
-
         prop = self._to_bool(value) if self.data_type == "bool" else PROPERTY_TYPES[self.data_type](value)
         return prop
 

--- a/tests/unit/xml/data/clinical_sample_1.xml
+++ b/tests/unit/xml/data/clinical_sample_1.xml
@@ -22,6 +22,7 @@
         <clin_shared:vital_status preferred_name="vital_status" display_order="30" cde="5" cde_ver="5.000" xsd_ver="2.6" tier="2" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663353">dead</clin_shared:vital_status>
         <clin_shared:days_to_birth precision="day" xsd_ver="1.12" tier="1" cde="3008233" owner="TSS" procurement_status="Completed" preferred_name="birth_days_to" display_order="16" cde_ver="1.000">-25469</clin_shared:days_to_birth>
         <clin_shared:days_to_last_known_alive precision="day" xsd_ver="2.1" tier="2" cde="" owner="TSS" procurement_status="Not Available" preferred_name="" display_order="9999" cde_ver=""/>
+        <clin_shared:missing_computation_tag precision="day" xsd_ver="2.1" tier="2" cde="" owner="TSS" procurement_status="Not Available" preferred_name="" display_order="9999" cde_ver=""/>
         <clin_shared:days_to_death precision="day" xsd_ver="1.12" tier="1" cde="3165475" owner="TSS" procurement_status="Not Applicable" preferred_name="death_days_to" display_order="38" cde_ver="1.000"/>
         <clin_shared:days_to_last_followup precision="day" xsd_ver="1.12" tier="1" cde="3008273" owner="TSS" procurement_status="Completed" preferred_name="last_contact_days_to" display_order="34" cde_ver="1.000">4549</clin_shared:days_to_last_followup>
         <clin_shared:race_list>

--- a/tests/unit/xml/test_field_evaluators.py
+++ b/tests/unit/xml/test_field_evaluators.py
@@ -8,7 +8,12 @@ from sheepdog.xml.evaluators.fields import BasicEvaluator, FilterElementEvaluato
 @pytest.mark.parametrize("props, expected",
                          [(dict(path="//admin:file_uuid", nullable="false"), "2940CCCF-533D-4834-A321-2814898DE639"),
                           (dict(path="//admin:file_uuidx", nullable="true"), None),
-                          (dict(path="//admin:day_of_dcc_upload", nullable="false", type="int"), 22)])
+                          (dict(path="//missing_computation_tag * -1", nullable="true", type="int"), None),
+                          (dict(path="//admin:day_of_dcc_upload", nullable="false", type="int"), 22)],
+                         ids=["Basic get from XML not nullable string type",
+                              "Get Missing Element and nullable",
+                              "Handle NaN for int computation",
+                              "Basic get from XML not nullable int type"])
 def test_basic_evaluator(xml_fixture, props, expected):
 
     xml = etree.fromstring(xml_fixture)


### PR DESCRIPTION
Some of the columns are computed using the formula `xml path value * -1`. Whenever this value is not set `lxml` returns a `nan` value as the result of the computation. Usually the dictionary/mapping expects the result to be an `int` data type, so the parser errors out with `NaN is not an integer`.

The code already handles `NaN` types but only for `floats`. This PR expands it to cover `int` types
