### PR TITLE
fix(xml): add support for unique value evaluator

### DIFF
--- a/sheepdog/xml/evaluators/fields.py
+++ b/sheepdog/xml/evaluators/fields.py
@@ -8,7 +8,7 @@ class BasicEvaluator(Evaluator):
     """
 
     def _evaluate(self):
-        """ Searches sml root for the property path and raises an exceoption if multiple paths are found
+        """ Searches xml root for the property path and raises an exceoption if multiple paths are found
         Returns:
              Any: text value for path in the xml
         Raises:
@@ -155,3 +155,17 @@ class TreatmentTherapyEvaluator(Evaluator):
     @staticmethod
     def is_radiation(path):
         return "radiation_therapy" in path
+
+
+class UniqueValueEvaluator(BasicEvaluator):
+    """ Searches XML and returns a value only if all elements found for
+        path has the same value, None values are omitted by the search
+        query
+    """
+
+    def _evaluate(self):
+        elements = self.search_path()  # list[str]
+        unique_values = set(elements)
+        if len(unique_values) == 1:
+            return unique_values.pop()
+        return None

--- a/tests/unit/xml/data/clinical_sample_1.xml
+++ b/tests/unit/xml/data/clinical_sample_1.xml
@@ -34,6 +34,7 @@
         <shared:bcr_patient_uuid preferred_name="" display_order="9999" cde="" cde_ver="" xsd_ver="2.3" owner="TSS" procurement_status="Completed" restricted="false">5813997A-D7DC-4F7C-8D4B-E979832168A9</shared:bcr_patient_uuid>
         <shared:history_of_neoadjuvant_treatment preferred_name="history_neoadjuvant_treatment" display_order="20" cde="3382737" cde_ver="1.000" xsd_ver="2.4" tier="1" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663343">No</shared:history_of_neoadjuvant_treatment>
         <clin_shared:informed_consent_verified preferred_name="patient_consent_status" display_order="73" cde="3288361" cde_ver="1.000" xsd_ver="2.4" tier="1" owner="TSS" procurement_status="Completed" restricted="false">YES</clin_shared:informed_consent_verified>
+        <clin_shared:unique_value_test preferred_name="" display_order="9999" cde="3226281" cde_ver="" xsd_ver="2.4" tier="2" owner="TSS" procurement_status="Completed" restricted="false">C34.1</clin_shared:unique_value_test>
         <clin_shared:icd_o_3_site preferred_name="" display_order="9999" cde="3226281" cde_ver="" xsd_ver="2.4" tier="2" owner="TSS" procurement_status="Completed" restricted="false">C34.1</clin_shared:icd_o_3_site>
         <clin_shared:icd_o_3_histology preferred_name="" display_order="9999" cde="3226275" cde_ver="" xsd_ver="2.4" tier="2" owner="TSS" procurement_status="Completed" restricted="false">8140/3</clin_shared:icd_o_3_histology>
         <clin_shared:icd_10 preferred_name="" display_order="9999" cde="3226287" cde_ver="" xsd_ver="2.4" tier="2" owner="TSS" procurement_status="Completed" restricted="false">C34.1</clin_shared:icd_10>
@@ -49,6 +50,7 @@
         <clin_shared:month_of_form_completion preferred_name="form_completion_month" display_order="999" cde="2975718" cde_ver="1.000" xsd_ver="2.2" tier="2" owner="TSS" procurement_status="Completed" restricted="false">6</clin_shared:month_of_form_completion>
         <clin_shared:year_of_form_completion preferred_name="form_completion_year" display_order="999" cde="2975720" cde_ver="1.000" xsd_ver="2.2" tier="2" owner="TSS" procurement_status="Completed" restricted="false">2014</clin_shared:year_of_form_completion>
         <shared_stage:stage_event system="AJCC">
+            <clin_shared:unique_value_test preferred_name="" display_order="9999" cde="3226281" cde_ver="" xsd_ver="2.4" tier="2" owner="TSS" procurement_status="Completed" restricted="false">C34.12</clin_shared:unique_value_test>
             <shared_stage:system_version preferred_name="ajcc_staging_edition" display_order="25" cde="2722309" cde_ver="1.000" xsd_ver="2.6" tier="1" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663348">6th</shared_stage:system_version>
             <shared_stage:clinical_stage preferred_name="ajcc_clinical_tumor_stage" display_order="38" cde="3440332" cde_ver="1.000" xsd_ver="2.6" tier="2" owner="TSS" procurement_status="Not Applicable" restricted="false"/>
             <shared_stage:pathologic_stage preferred_name="ajcc_pathologic_tumor_stage" display_order="29" cde="3203222" cde_ver="1.000" xsd_ver="2.6" tier="2" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663352">Stage IIB</shared_stage:pathologic_stage>
@@ -115,6 +117,7 @@
         <luad_nte:new_tumor_events>
             <nte:new_tumor_event_after_initial_treatment preferred_name="new_tumor_event_dx_indicator" display_order="64" cde="3121376" cde_ver="1.000" xsd_ver="2.5" tier="1" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663421">YES</nte:new_tumor_event_after_initial_treatment>
             <luad_nte:new_tumor_event>
+                <clin_shared:days_to_initial_pathologic_diagnosis precision="day" xsd_ver="1.12" tier="1" cde="3131740" owner="TSS" procurement_status="Completed" preferred_name="initial_pathologic_dx_days_to" display_order="9999" cde_ver="1.000">0</clin_shared:days_to_initial_pathologic_diagnosis>
                 <nte:days_to_new_tumor_event_after_initial_treatment precision="day" xsd_ver="2.2" tier="1" cde="3392464" owner="TSS" procurement_status="Completed" preferred_name="new_tumor_event_dx_days_to" display_order="68" cde_ver="1.000">1893</nte:days_to_new_tumor_event_after_initial_treatment>
                 <luad_nte:new_neoplasm_event_types>
                     <nte:new_neoplasm_event_type preferred_name="new_tumor_event_type" display_order="69" cde="3119721" cde_ver="1.000" xsd_ver="2.5" tier="2" owner="TSS" procurement_status="Completed" restricted="false" source_system_identifier="3663426">Locoregional Recurrence</nte:new_neoplasm_event_type>

--- a/tests/unit/xml/test_field_evaluators.py
+++ b/tests/unit/xml/test_field_evaluators.py
@@ -1,8 +1,7 @@
 from lxml import etree
 import pytest
 
-from sheepdog.xml.evaluators.fields import BasicEvaluator, FilterElementEvaluator, LastFollowUpEvaluator, \
-    TreatmentTherapyEvaluator, VitalStatusEvaluator
+from sheepdog.xml.evaluators import fields
 
 
 @pytest.mark.parametrize("props, expected",
@@ -18,7 +17,7 @@ def test_basic_evaluator(xml_fixture, props, expected):
 
     xml = etree.fromstring(xml_fixture)
     nspace = xml.nsmap
-    evaluator = BasicEvaluator(xml, nspace, props)
+    evaluator = fields.BasicEvaluator(xml, nspace, props)
     assert expected == evaluator.evaluate()
 
 
@@ -32,7 +31,7 @@ def test_filter_evaluator(xml_fixture, props, expected):
 
     xml = etree.fromstring(xml_fixture)
     nspace = xml.nsmap
-    evaluator = FilterElementEvaluator(xml, nspace, props)
+    evaluator = fields.FilterElementEvaluator(xml, nspace, props)
     assert expected == evaluator.evaluate()
 
 
@@ -43,7 +42,7 @@ def test_last_follow_up_evaluator(xml_fixture, props, expected):
 
     xml = etree.fromstring(xml_fixture).xpath("//*[local-name()='patient']")[0]
     nspace = xml.nsmap
-    evaluator = LastFollowUpEvaluator(xml, nspace, props)
+    evaluator = fields.LastFollowUpEvaluator(xml, nspace, props)
     assert expected == evaluator.evaluate()
 
 
@@ -57,7 +56,7 @@ def test_vital_status_evaluator(xml_fixture, props, expected):
 
     xml = etree.fromstring(xml_fixture).xpath("//*[local-name()='patient']")[0]
     nspace = xml.nsmap
-    evaluator = VitalStatusEvaluator(xml, nspace, props)
+    evaluator = fields.VitalStatusEvaluator(xml, nspace, props)
     assert expected == evaluator.evaluate()
 
 
@@ -81,5 +80,26 @@ def test_treatment_or_therapy_evaluator(xml_radiation_fixture, props, expected):
 
     xml = etree.fromstring(xml_radiation_fixture).xpath("//*[local-name()='patient']")[0]
     nspace = xml.nsmap
-    evaluator = TreatmentTherapyEvaluator(xml, nspace, props)
+    evaluator = fields.TreatmentTherapyEvaluator(xml, nspace, props)
+    assert expected == evaluator.evaluate()
+
+
+@pytest.mark.parametrize("props, expected",
+                         [(dict(path="//admin:file_uuid/text()", nullable="false",
+                                evaluator=dict(
+                                    name="unique_value"
+                                )), "2940CCCF-533D-4834-A321-2814898DE639"),
+                          (dict(path="//clin_shared:days_to_initial_pathologic_diagnosis/text()",
+                                evaluator=dict(
+                                    name="unique_value"
+                                ), type="int"), 0),
+                          (dict(path="//clin_shared:unique_value_test/text()",
+                                evaluator=dict(
+                                    name="unique_value"
+                                ), type="str.title", default="not reported"), "Not Reported")])
+def test_unique_value_evaluator(xml_fixture, props, expected):
+
+    xml = etree.fromstring(xml_fixture)
+    nspace = xml.nsmap
+    evaluator = fields.UniqueValueEvaluator(xml, nspace, props)
     assert expected == evaluator.evaluate()


### PR DESCRIPTION
PR adds support for searching XML globally and selecting a value only if it is a unique value in the sense that all element found must have that same value else it returns None or the default value